### PR TITLE
Fix timeouts in install_julia

### DIFF
--- a/R/installJulia.R
+++ b/R/installJulia.R
@@ -93,7 +93,10 @@ install_julia <- function(version = "latest",
 
     file <- tempfile()
     tryCatch({
+        old_timeout = getOption("timeout")
+        options(timeout = 300)
         utils::download.file(url, file)
+        options(timeout = old_timeout)
     }, error = function(err) {
         stop(paste("There was an error downloading Julia. This could be due ",
                    "to network issues, and might be resolved by re-running ",


### PR DESCRIPTION
The current default timeout is too low for the current binary size so it tends to fail on v1.9. This makes it more robust.

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
